### PR TITLE
[Refactor] Fix API response transformation for statistics endpoint 

### DIFF
--- a/frontend/src/components/StatsDashboard.vue
+++ b/frontend/src/components/StatsDashboard.vue
@@ -250,7 +250,7 @@ const fetchStatistics = async (): Promise<boolean> => {
       // 実際の日別統計設定
       dailyStats.value = response.data.dailyStats || []
       
-      // 실제の 人気時間帯統計から人気時間帯生成
+      // 実際の 人気時間帯統計から人気時間帯生成
       if (response.data.popularRanges && response.data.popularRanges.length > 0) {
         popularRanges.value = response.data.popularRanges.map((stat, index) => ({
           id: index + 1,
@@ -263,8 +263,8 @@ const fetchStatistics = async (): Promise<boolean> => {
         popularRanges.value = []
       }
       
-      // 実際のユニークセッション数（総チェック数の70%程度で推定）
-      uniqueSessions.value = Math.floor(totalChecks.value * 0.7)
+      // 実際のユニークセッション数を使用
+      uniqueSessions.value = response.data.uniqueSessions || 0
       
       // 成功率計算（API応答時間に応じて）
       successRate.value = averageResponseTime.value < 1000 ? 98.5 : 95.0

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -29,6 +29,29 @@ interface BackendTimeCheckResponse {
   }
 }
 
+// バックエンド統計応答形式
+interface BackendStatsResponse {
+  code: number
+  message: string
+  data?: {
+    totalRequests: number
+    uniqueSessions: number
+    popularRanges: Array<{
+      rangeKey: string
+      requestCount: number
+      matchCount: number
+      matchRate: number
+      lastAccessed: string
+    }>
+    dailyStats: Array<{
+      date: string
+      totalRequests: number
+      uniqueSessions: number
+      popularRange: string
+    }>
+  }
+}
+
 class ApiService {
   private async request<T>(
     endpoint: string, 
@@ -110,7 +133,21 @@ class ApiService {
 
   // 統計情報取得API呼び出し
   async getStatistics(): Promise<StatsResponse> {
-    return this.request<StatsResponse>('/api/v1/statistics/overall')
+    const backendResponse = await this.request<BackendStatsResponse>('/api/v1/statistics/overall')
+    
+    // codeが200なら成功として処理
+    const isSuccess = backendResponse.code === 200
+    
+    return {
+      success: isSuccess,
+      message: backendResponse.message,
+      data: backendResponse.data ? {
+        totalRequests: backendResponse.data.totalRequests,
+        uniqueSessions: backendResponse.data.uniqueSessions,
+        popularRanges: backendResponse.data.popularRanges,
+        dailyStats: backendResponse.data.dailyStats
+      } : undefined
+    }
   }
 }
 


### PR DESCRIPTION
統計ダッシュボードにデータが正常に表示される
総リクエスト数、人気時間帯、日別統計が表示される
エラーハンドリングが正常に動作する